### PR TITLE
bastion wrapper : manage ansible env vars from playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@ group_vars/zone_secure.yml:bastion_host: <your-supersecure-bastion>
 
 For more information have a look at [the official documentation](https://docs.ansible.com/ansible/latest/network/getting_started/first_inventory.html)
 
+## Using env vars from a playbook
+
+In some cases, like the usage of multiple bastions for a single ansible controller and multiple inventory sources, it may be useful to set the vars in the environment configuration from the playbook.
+
+It can also be combined with the group_vars.
+
+Example:
+```yaml
+---
+- hosts: all
+  gather_facts: false
+  environment:
+    BASTION_USER: "{{ bastion_user }}"
+    BASTION_HOST: "{{ bastion_host }}"
+    BASTION_PORT: "{{ bastion_port }}"
+  tasks:
+  ...
+```
+
+here, each host may have its bastion_X vars defined in group_vars and host_vars.
+
+If environement vars are not defined, or if the module does not send them, then the sshwrapper is doing a lookup on the ansible-inventory to fetch the bastion_X vars.
+
+## Using multiple inventories sources
+
+The wrapper is going to lookup the ansible inventory to look for the host and its vars.
+
+You may define multiple inventories sources in an ENV var. Example: 
+
+export BASTION_ANSIBLE_INV_OPTIONS='-i my_first_inventory_source -i my_second_inventory_source'
+
 ## Configuration via ansible.cfg
 
 ```ini
@@ -108,3 +139,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+

--- a/lib.py
+++ b/lib.py
@@ -35,7 +35,11 @@ def get_inventory():
     inventory_cmd = find_executable("ansible-inventory")
     if not inventory_cmd:
         raise Exception("Failed to identify path of ansible-inventory")
-    command = "{} --list".format(inventory_cmd)
+
+    # ex : export BASTION_ANSIBLE_INV_OPTIONS="-i my_inventory -i my_second_inventory"
+    inventory_options = os.environ.get("BASTION_ANSIBLE_INV_OPTIONS", "")
+
+    command = "{} {} --list".format(inventory_cmd, inventory_options)
     p = subprocess.Popen(
         command,
         shell=True,
@@ -71,3 +75,4 @@ def get_hostvars(ipaddr):
         ][0]
     except IndexError:  # ipaddr not found in inventory, should never happen as this is called by ansible
         return {}
+


### PR DESCRIPTION
manage bastion_X vars passed from an ansible playbook.

Our ansible controllers may have to manage different bastions, from different inventories sources, so we can not rely on a ENV var.

Our hosts may come from different inventories sources, but the sshwrapper does not allow to pass options to its inventory lookup to configure a source.
Using consul as an inventory source (https://github.com/wilfriedroset/consul-awx), it generates a lot of output (~ 50000 lines for some instances)

Then each call to ansible-inventory from the sshwrapper are registered in the ansible log...which end up in 100+ millions of lines for 2 runs on 650 hosts.
And each call to consul takes around 15-20s.

So we try to avoid doing a lookup by getting vars from the args sent to the ssh wrapper first, then do an inventory lookup if none found