### PR TITLE
feat: Use Python 3 interpreter (#2)

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 import json
 import logging
 import os

--- a/scpwrapper.py
+++ b/scpwrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import getpass
 import os

--- a/sshwrapper.py
+++ b/sshwrapper.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 
 import getpass
 import os


### PR DESCRIPTION
- Remove shebang from lib.py because it's only imported, not executed.
- Use '/usr/bin/env python3' interpreter to use Python 3 instead of Python 2
  because this version has been deprecated in 2020.

Signed-off-by: Julien Riou <julien@riou.xyz>