### PR TITLE
- feat: add the ability to fetch the vars from a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ here, each host may have its bastion_X vars defined in group_vars and host_vars.
 
 If environement vars are not defined, or if the module does not send them, then the sshwrapper is doing a lookup on the ansible-inventory to fetch the bastion_X vars.
 
+## Using vars from a config file
+For some use cases (AWX in a non containerised environment for instance), the environment is override by the job, and there is no fixed inventory source path.
+
+So we may not get the vars from the environment nor the inventory.
+
+In this case, we may use a configuration file to provide the BASTION vars.
+
+Example:
+
+```
+cat /etc/ovh/bastion_wrapper_conf.yml
+
+---
+bastion_host: "my_great_bastion"
+bastion_port: 22
+bastion_user: "my_bastion_user"
+```
+
+The configuration file is read after checking the environment variables sent in the ssh command line, and will only set them if not defined.
+
 ## Using multiple inventories sources
 
 The wrapper is going to lookup the ansible inventory to look for the host and its vars.

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,0 +1,4 @@
+---
+bastion_host: "my_great_bastion"
+bastion_port: 22
+bastion_user: "my_bastion_user"

--- a/lib.py
+++ b/lib.py
@@ -3,6 +3,7 @@ import logging
 import os
 import subprocess
 import time
+from yaml import safe_load, YAMLError
 
 
 def find_executable(executable, path=None):
@@ -117,3 +118,28 @@ def get_hostvars(host):
             return hostvars
     # Host not found
     return {}
+
+
+def manage_conf_file(conf_file, bastion_host, bastion_port, bastion_user):
+    """Fetch the bastion vars from a config file.
+    
+        There will be set if not already defined, and before looking in the ansible inventory
+    
+    """
+
+    if os.path.exists(conf_file):
+        try:
+            with open(conf_file, "r") as f:
+                yaml_conf = safe_load(f)
+
+                if not bastion_host:
+                    bastion_host = yaml_conf.get("bastion_host")
+                if not bastion_port:
+                    bastion_port = yaml_conf.get("bastion_port")
+                if not bastion_user:
+                    bastion_user = yaml_conf.get("bastion_user")
+
+        except (YAMLError, IOError) as e:
+            print("Error loading yaml file: {}".format(e))
+
+    return bastion_host, bastion_port, bastion_user

--- a/sshwrapper.py
+++ b/sshwrapper.py
@@ -4,7 +4,7 @@ import getpass
 import os
 import sys
 
-from lib import find_executable, get_hostvars
+from lib import find_executable, get_hostvars, manage_conf_file
 
 
 def main():
@@ -15,6 +15,7 @@ def main():
     bastion_port = None
     remote_user = None
     remote_port = 22
+    default_configuration_file = "/etc/ovh/bastion/config.yml"
 
     cmd = argv.pop()
     host = argv.pop()
@@ -37,6 +38,11 @@ def main():
             bastion_host = i.split("=")[1]
         elif "bastion_port" in i.lower():
             bastion_port = i.split("=")[1]
+
+    # in some cases (AWX in a non containerised environment for instance), the environment is override by the job
+    # so we are not able to get the BASTION vars
+    # if some vars are still undefined, try to load them from a configuration file
+    bastion_host, bastion_port, bastion_user = manage_conf_file(os.environ.get("BASTION_CONF_FILE", default_configuration_file), bastion_host, bastion_port, bastion_user)
 
     # lookup on the inventory may take some time, depending on the source, so use it only if not defined elsewhere
     # it seems like some module like template does not send env vars too...

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,45 @@
+from lib import manage_conf_file
+from yaml import dump
+
+BASTION_HOST = "my_bastion"
+BASTION_PORT = 22
+BASTION_USER = "my_bastion_user"
+BASTION_CONF_FILE = "/tmp/test_bastion_conf_file.yml"
+
+
+def test_bastion_host_undefined():
+    bastion_host, bastion_port, bastion_user = manage_conf_file(BASTION_CONF_FILE, None, BASTION_PORT, BASTION_USER)
+    assert bastion_host == BASTION_HOST
+
+
+def test_bastion_port_undefined():
+    bastion_host, bastion_port, bastion_user = manage_conf_file(BASTION_CONF_FILE, BASTION_HOST, None, BASTION_USER)
+    assert bastion_port == BASTION_PORT
+
+
+def test_bastion_user_undefined():
+    bastion_host, bastion_port, bastion_user = manage_conf_file(BASTION_CONF_FILE, BASTION_HOST, BASTION_PORT, None)
+    assert bastion_user == BASTION_USER
+
+
+def test_bastion_all_undefined():
+    write_conf_file(BASTION_CONF_FILE)
+    bastion_host, bastion_port, bastion_user = manage_conf_file(BASTION_CONF_FILE, None, None, None)
+    assert bastion_user == BASTION_USER
+    assert bastion_port == BASTION_PORT
+    assert bastion_host == BASTION_HOST
+
+
+def write_conf_file(conf_file):
+    with open(conf_file, 'w') as f:
+
+        data = {
+            "bastion_host": BASTION_HOST,
+            "bastion_port": BASTION_PORT,
+            "bastion_user": BASTION_USER
+        }
+
+        dump(data, f)
+
+
+write_conf_file(BASTION_CONF_FILE)


### PR DESCRIPTION
In some cases (AWX in a non containerised environment for instance), the environment is override by the job, so we are not able to get the BASTION vars.
So, if some vars are not defined from the ssh command line, we look for them in a conf file (if exists), before looking up in the inventory