### PR TITLE
Disable pseudo-terminal allocation as ansible does not need one

### DIFF
--- a/sshwrapper.py
+++ b/sshwrapper.py
@@ -70,12 +70,13 @@ def main():
             "-l",
             bastion_user,
             bastion_host,
-            "-t",
+            "-T",
         ]
         + argv
         + [
             "--",
             "-q",
+            "-T",
             "--never-escape",
             "--user",
             remote_user,


### PR DESCRIPTION
Signed-off-by: Wilfried Roset <wilfriedroset@users.noreply.github.com>