### PR TITLE
Manage cache file race conditions

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,5 +11,6 @@
 #
 # Please keep the list sorted.
 #
+Nicolas Payart <npayart@gmail.com>
 Stéphane Lesimple <stephane.lesimple+bastion@ovhcloud.com>
 Wifried Roset <wilfried.roset@ovhcloud.com>


### PR DESCRIPTION
Checking cache_file existence and opening it is not an atomic operation and can lead to errors if cache file has been removed in the meantime.

In the same way, we can't be sure that the cache file exists when we delete it.

Handle exceptions on opening and loading JSON file:
- For IO errors (file probably does not exist), return None
- For any other error (invalid JSON or else), or when cache is expired, remove the cache file and return None
