### PR TITLE
feat: resolve jinja vars from hostvars

### DIFF
--- a/sshwrapper.py
+++ b/sshwrapper.py
@@ -4,7 +4,7 @@ import getpass
 import os
 import sys
 
-from lib import find_executable, get_hostvars, manage_conf_file
+from lib import find_executable, get_hostvars, get_var_within, manage_conf_file
 
 
 def main():
@@ -54,11 +54,18 @@ def main():
     if not bastion_host or not bastion_port or not bastion_user:
         hostvar = get_hostvars(host)  # dict
 
-        bastion_port = hostvar.get("bastion_port", os.environ.get("BASTION_PORT", 22))
-        bastion_user = hostvar.get(
-            "bastion_user", os.environ.get("BASTION_USER", getpass.getuser())
+        bastion_port = get_var_within(
+            hostvar.get("bastion_port", os.environ.get("BASTION_PORT", 22)), hostvar
         )
-        bastion_host = hostvar.get("bastion_host", os.environ.get("BASTION_HOST"))
+        bastion_user = get_var_within(
+            hostvar.get(
+                "bastion_user", os.environ.get("BASTION_USER", getpass.getuser())
+            ),
+            hostvar,
+        )
+        bastion_host = get_var_within(
+            hostvar.get("bastion_host", os.environ.get("BASTION_HOST")), hostvar
+        )
 
     for i, e in enumerate(argv):
 

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,6 @@
 from yaml import dump
 
-from lib import manage_conf_file
+from lib import get_var_within, manage_conf_file
 
 BASTION_HOST = "my_bastion"
 BASTION_PORT = 22
@@ -8,28 +8,28 @@ BASTION_USER = "my_bastion_user"
 BASTION_CONF_FILE = "/tmp/test_bastion_conf_file.yml"
 
 
-def test_bastion_host_undefined():
+def test_manage_conf_file_bastion_host_undefined():
     bastion_host, bastion_port, bastion_user = manage_conf_file(
         BASTION_CONF_FILE, None, BASTION_PORT, BASTION_USER
     )
     assert bastion_host == BASTION_HOST
 
 
-def test_bastion_port_undefined():
+def test_manage_conf_file_bastion_port_undefined():
     bastion_host, bastion_port, bastion_user = manage_conf_file(
         BASTION_CONF_FILE, BASTION_HOST, None, BASTION_USER
     )
     assert bastion_port == BASTION_PORT
 
 
-def test_bastion_user_undefined():
+def test_manage_conf_file_bastion_user_undefined():
     bastion_host, bastion_port, bastion_user = manage_conf_file(
         BASTION_CONF_FILE, BASTION_HOST, BASTION_PORT, None
     )
     assert bastion_user == BASTION_USER
 
 
-def test_bastion_all_undefined():
+def test_manage_conf_file_bastion_all_undefined():
     write_conf_file(BASTION_CONF_FILE)
     bastion_host, bastion_port, bastion_user = manage_conf_file(
         BASTION_CONF_FILE, None, None, None
@@ -52,3 +52,40 @@ def write_conf_file(conf_file):
 
 
 write_conf_file(BASTION_CONF_FILE)
+
+
+def test_get_var_within_one_level():
+    hostvars = {"bastion_host": "{{ bastion_fqdn }}", "bastion_fqdn": "my_real_bastion"}
+    bastion_host = get_var_within(hostvars["bastion_host"], hostvars)
+    assert bastion_host == hostvars["bastion_fqdn"]
+
+
+def test_get_var_within_two_levels():
+    hostvars = {
+        "bastion_host": "{{ bastion_fqdn }}",
+        "bastion_fqdn": "{{ my_other_var }}",
+        "my_other_var": "my_real_bastion",
+    }
+    bastion_host = get_var_within(hostvars["bastion_host"], hostvars)
+    assert bastion_host == hostvars["my_other_var"]
+
+
+def test_get_var_within_not_found():
+    hostvars = {"bastion_host": "{{ bastion_fqdn }}"}
+    bastion_host = get_var_within(hostvars["bastion_host"], hostvars)
+    assert not bastion_host
+
+
+def test_get_var_within_infinite():
+    hostvars = {
+        "bastion_host": "{{ bastion_fqdn }}",
+        "bastion_fqdn": "{{ bastion_host }}",
+    }
+    bastion_host = get_var_within(hostvars["bastion_host"], hostvars)
+    assert not bastion_host
+
+
+def test_get_var_not_a_jinja2_var():
+    hostvars = {"bastion_host": "{{ bastion_fqdn"}
+    bastion_host = get_var_within(hostvars["bastion_host"], hostvars)
+    assert bastion_host == hostvars["bastion_host"]


### PR DESCRIPTION
Currently the bastion-ansible-wrapper does not mananage jinja2 vars. Example group vars defining bastion_host:
```
"bastion_host": "{{ bastion_fqdn }}"
```
-> this will be interpreted as a litteral string

This PR tries to resolve the (maybe intricated) jinja2 vars by looking at them in hostvars