### PR TITLE
feat: Add SFTP support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@
 #
 # Please keep the list sorted.
 #
+Julien Riou <julien.riou@ovhcloud.com>
 Nicolas Payart <npayart@gmail.com>
 Stéphane Lesimple <stephane.lesimple+bastion@ovhcloud.com>
 Wifried Roset <wilfried.roset@ovhcloud.com>

--- a/README.md
+++ b/README.md
@@ -118,16 +118,63 @@ You may define multiple inventories sources in an ENV var. Example:
 
 export BASTION_ANSIBLE_INV_OPTIONS='-i my_first_inventory_source -i my_second_inventory_source'
 
-## Configuration via ansible.cfg
+## Connection via SSH
+
+The wrapper can be configured using `ansible.cfg` file as follow:
 
 ```ini
 [ssh_connection]
-scp_if_ssh = True
-# Rely on bastion wrapper
 pipelining = True
 ssh_executable = ./extra/bastion/sshwrapper.py
+```
+
+Or by using the `ANSIBLE_SSH_PIPELINING` and `ANSIBLE_SSH_EXECUTABLE`
+environment variables.
+
+## File transfer using SFTP
+
+By default, Ansible uses SFTP to copy files. The executable should be defined
+as follow in the ansible.cfg file:
+
+```ini
+[ssh_connection]
+transfer_method = sftp
+sftp_executable = ./extra/bastion/sftpbastion.sh
+```
+
+Or by using the `ANSIBLE_SFTP_EXECUTABLE` environment variable.
+
+## File transfer using SCP (deprecated)
+
+The SCP protocol is still allowed but will soon deprecated by OpenSSH. You
+should consider using SFTP instead. If you still want to use the SCP protocol,
+you can define the method and executable as follow:
+
+File ansible.cfg:
+
+```ini
+[ssh_connection]
+transfer_method = scp
+scp_if_ssh = True       # Ansible < 2.17
+scp_extra_args = -O     # OpenSSH >= 9.0
 scp_executable = ./extra/bastion/scpbastion.sh
-transfer_method =  scp
+```
+
+Or by using the following environment variables:
+* `ANSIBLE_SCP_IF_SSH`
+* `ANSIBLE_SSH_TRANSFER_METHOD`
+* `ANSIBLE_SCP_EXTRA_ARGS`
+* `ANSIBLE_SCP_EXECUTABLE`
+
+## Configuration example
+
+File ansible.cfg:
+
+```ini
+[ssh_connection]
+pipelining = True
+ssh_executable = ./extra/bastion/sshwrapper.py
+sftp_executable = ./extra/bastion/sftpbastion.sh
 ```
 
 ## Integration via submodule

--- a/sftpbastion.sh
+++ b/sftpbastion.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec sftp -S $(dirname $0)/sftpwrapper.py "$@"

--- a/sftpwrapper.py
+++ b/sftpwrapper.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+import getpass
+import os
+import sys
+
+from lib import find_executable, get_hostvars, manage_conf_file
+
+
+def main():
+    argv = list(sys.argv[1:])
+
+    bastion_user = None
+    bastion_host = None
+    bastion_port = None
+    remote_user = None
+    remote_port = 22
+    default_configuration_file = "/etc/ovh/bastion/config.yml"
+
+    iteration = enumerate(argv)
+    for i, e in iteration:
+        if e == "-o" and argv[i + 1].startswith("User="):
+            remote_user = argv[i + 1].split("=")[-1]
+            next(iteration)
+        elif e == "-o" and argv[i + 1].startswith("Port="):
+            remote_port = argv[i + 1].split("=")[-1]
+            next(iteration)
+
+    sftpcmd = argv.pop()
+    host = argv.pop()
+
+    # Playbook environment variables are not pushed to the sftp wrapper
+    # Skipping this source of configuration
+
+    # Read from configuration file
+    bastion_host, bastion_port, bastion_user = manage_conf_file(
+        os.getenv("BASTION_CONF_FILE", default_configuration_file),
+        bastion_host,
+        bastion_port,
+        bastion_user,
+    )
+
+    # Read from inventory and environment variables
+    if not bastion_host or not bastion_port or not bastion_user:
+        inventory = get_hostvars(host)
+        bastion_port = inventory.get("bastion_port", os.getenv("BASTION_PORT", 22))
+        bastion_user = inventory.get(
+            "bastion_user", os.getenv("BASTION_USER", getpass.getuser())
+        )
+        bastion_host = inventory.get("bastion_host", os.getenv("BASTION_HOST"))
+
+    args = [
+        "ssh",
+        "{}@{}".format(bastion_user, bastion_host),
+        "-p",
+        bastion_port,
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-T",
+        "--",
+        "--user",
+        remote_user,
+        "--port",
+        remote_port,
+        "--host",
+        host,
+        "--osh",
+        "sftp",
+    ]
+
+    os.execv(
+        find_executable("ssh"),
+        [str(e).strip() for e in args],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The SCP protocol is still allowed but will soon deprecated by OpenSSH and [it's already the case for RHEL based Linux distributions](https://www.redhat.com/en/blog/openssh-scp-deprecation-rhel-9-what-you-need-know). Thanks to @speed47, I've been able to test a patched version of The Bastion with SFTP support. This pull request enables the Ansible wrapper to use SFTP on a compatible version of The Bastion.