### PR TITLE
fix(scp): Read from configuration file (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ here, each host may have its bastion_X vars defined in group_vars and host_vars.
 If environement vars are not defined, or if the module does not send them, then the sshwrapper is doing a lookup on the ansible-inventory to fetch the bastion_X vars.
 
 ## Using vars from a config file
+
 For some use cases (AWX in a non containerised environment for instance), the environment is overridden by the job, and there is no fixed inventory source path.
 
 So we may not get the vars from the environment nor the inventory.
@@ -102,6 +103,9 @@ bastion_user: "my_bastion_user"
 
 The configuration file is read after checking the environment variables sent in the ssh command line, and will only set them if not defined.
 
+The location of the configuration file can be set with `BASTION_CONFIG_FILE`
+environment variable (defaults to `/etc/ovh/bastion/config.yml`).
+
 ## Configuration priority
 
 Source of variables are read in the following order:
@@ -116,7 +120,9 @@ The wrapper is going to lookup the ansible inventory to look for the host and it
 
 You may define multiple inventories sources in an ENV var. Example:
 
+```
 export BASTION_ANSIBLE_INV_OPTIONS='-i my_first_inventory_source -i my_second_inventory_source'
+```
 
 ## Connection via SSH
 

--- a/scpwrapper.py
+++ b/scpwrapper.py
@@ -4,7 +4,7 @@ import getpass
 import os
 import sys
 
-from lib import find_executable, get_hostvars
+from lib import find_executable, get_hostvars, manage_conf_file
 
 
 def main():
@@ -15,6 +15,7 @@ def main():
     bastion_port = None
     remote_user = None
     remote_port = 22
+    default_configuration_file = "/etc/ovh/bastion/config.yml"
 
     iteration = enumerate(argv)
     sshcmdline = []
@@ -50,6 +51,14 @@ def main():
             bastion_host = i.split("=")[1]
         elif "bastion_port" in i.lower():
             bastion_port = i.split("=")[1]
+
+    # read from configuration file
+    bastion_host, bastion_port, bastion_user = manage_conf_file(
+        os.getenv("BASTION_CONF_FILE", default_configuration_file),
+        bastion_host,
+        bastion_port,
+        bastion_user,
+    )
 
     # lookup on the inventory may take some time, depending on the source, so use it only if not defined elsewhere
     # it seems like some module like template does not send env vars too...


### PR DESCRIPTION
This commit allows SCP wrapper to read from a configuration file like SSH and SFTP wrappers.