### PR TITLE
feat: add specific code path for AWX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,6 @@ repos:
         args: ['--remove']
       - id: requirements-txt-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ You may define multiple inventories sources in an ENV var. Example:
 export BASTION_ANSIBLE_INV_OPTIONS='-i my_first_inventory_source -i my_second_inventory_source'
 ```
 
+## Using the bastion wrapper with AWX
+
+When using AWX, the inventory is available as a file in the AWX Execution Environment.
+It is then easy and much faster to get the appropriate host from the IP sent by Ansible to the bastion wrapper.
+
+When AWX usage is detected, the bastion wrapper is going to:
+- lookup in the inventory file for the appropriate host
+- lookup for the bastion vars in the host_vars
+- if not found, run an inventory lookup on the host to get the group_vars too (and execute eventual vars plugins)
+
+The AWX usage is detected by looking for the inventory file, the default path being "/runner/inventory/hosts"
+The path may be changed y setting an "AWX_RUN_DIR" environment variable on the AWX worker.
+Ex on a AWX k8s instance group:
+```
+      env:
+      - name: "AWX_RUN_DIR"
+        value: "/my_folder/my_sub_folder"
+```
+The inventory file will be looked up at "/my_folder/my_sub_folder/inventory/hosts"
+
 ## Connection via SSH
 
 The wrapper can be configured using `ansible.cfg` file as follow:

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,13 @@
+import os
+
 from yaml import dump
 
-from lib import get_var_within, manage_conf_file
+from lib import (
+    awx_get_inventory_file,
+    get_bastion_vars,
+    get_var_within,
+    manage_conf_file,
+)
 
 BASTION_HOST = "my_bastion"
 BASTION_PORT = 22
@@ -95,3 +102,34 @@ def test_get_var_not_a_string():
     hostvars = {"bastion_host": 68}
     bastion_host = get_var_within(hostvars["bastion_host"], hostvars)
     assert bastion_host == hostvars["bastion_host"]
+
+
+def test_awx_get_inventory_file_default():
+    assert awx_get_inventory_file() == "/runner/inventory/hosts"
+
+
+def test_awx_get_inventory_file_env_defined():
+    env_path = "/my_awx"
+    os.environ["AWX_RUN_DIR"] = env_path
+    assert awx_get_inventory_file() == f"{env_path}/inventory/hosts"
+    os.environ.pop("AWX_RUN_DIR")
+
+
+def test_get_bastion_vars():
+    host_vars = {
+        "bastion_port": BASTION_PORT,
+        "bastion_host": BASTION_HOST,
+        "bastion_user": BASTION_USER,
+    }
+    bastion_vars = get_bastion_vars(host_vars)
+    assert (
+        bastion_vars["bastion_port"] == BASTION_PORT
+        and bastion_vars["bastion_host"] == BASTION_HOST
+        and bastion_vars["bastion_user"] == BASTION_USER
+    )
+
+
+def test_get_bastion_vars_not_full():
+    host_vars = {"bastion_port": BASTION_PORT, "bastion_user": BASTION_USER}
+    bastion_vars = get_bastion_vars(host_vars)
+    assert not bastion_vars["bastion_host"]


### PR DESCRIPTION
The ansible bastion wrapper default lookup to get bastion vars, is to run "ansible-inventory --list" A downside of this way of doing, is that the whole inventory is going to be evaluated, and if we are using some custom vars plugins, there are executed to. It can end up being very time consuming.

When using AWX, the whole inventory is available in the AWX Execution Environment as a file. So it is much easier and faster to get the host associated to the requested ip (the ip sent by Ansible to the ssh wrapper). Then, we can look for the bastion vars in the host vars, and if not found, execute "ansible-inventory --host" on the specific host, instead of the whole inventory.