### PR TITLE
Fix missing conditions

### DIFF
--- a/scpwrapper.py
+++ b/scpwrapper.py
@@ -53,12 +53,13 @@ def main():
             bastion_port = i.split("=")[1]
 
     # read from configuration file
-    bastion_host, bastion_port, bastion_user = manage_conf_file(
-        os.getenv("BASTION_CONF_FILE", default_configuration_file),
-        bastion_host,
-        bastion_port,
-        bastion_user,
-    )
+    if not bastion_host or not bastion_port or not bastion_user:
+        bastion_host, bastion_port, bastion_user = manage_conf_file(
+            os.getenv("BASTION_CONF_FILE", default_configuration_file),
+            bastion_host,
+            bastion_port,
+            bastion_user,
+        )
 
     # lookup on the inventory may take some time, depending on the source, so use it only if not defined elsewhere
     # it seems like some module like template does not send env vars too...

--- a/sshwrapper.py
+++ b/sshwrapper.py
@@ -49,12 +49,13 @@ def main():
     # in some cases (AWX in a non containerised environment for instance), the environment is overridden by the job
     # so we are not able to get the BASTION vars
     # if some vars are still undefined, try to load them from a configuration file
-    bastion_host, bastion_port, bastion_user = manage_conf_file(
-        os.environ.get("BASTION_CONF_FILE", default_configuration_file),
-        bastion_host,
-        bastion_port,
-        bastion_user,
-    )
+    if not bastion_host or not bastion_port or not bastion_user:
+        bastion_host, bastion_port, bastion_user = manage_conf_file(
+            os.environ.get("BASTION_CONF_FILE", default_configuration_file),
+            bastion_host,
+            bastion_port,
+            bastion_user,
+        )
 
     # lookup on the inventory may take some time, depending on the source, so use it only if not defined elsewhere
     # it seems like some module like template does not send env vars too...


### PR DESCRIPTION
L52 of sshwrapper unconditionnaly reset variables set on bloc starting L45. A condition should be added to keep values already set.

scpwrapper is also concerned.